### PR TITLE
Add K8S version field as variable from manifest

### DIFF
--- a/Infrastructure/provider/aws/inbound_data_plane/main.tf
+++ b/Infrastructure/provider/aws/inbound_data_plane/main.tf
@@ -137,10 +137,10 @@ module eks_cluster {
 }
 
 resource aws_ssm_parameter cluster_name {
-  tags        = var.tags
-  name        = format("/%s-%s/%s/inbound-data-plane/cluster-name", var.env_name, var.region, var.deployment_id)
-  type        = "SecureString"
-  value       = module.eks_cluster.cluster.name
+  tags  = var.tags
+  name  = format("/%s-%s/%s/inbound-data-plane/cluster-name", var.env_name, var.region, var.deployment_id)
+  type  = "SecureString"
+  value = module.eks_cluster.cluster.name
 }
 
 ###############################
@@ -156,18 +156,18 @@ resource aws_ec2_transit_gateway_vpc_attachment tgw_attachment {
 }
 
 module sitebridge_vpc_routing {
-  source                       = "../modules/sitebridge_vpc_routing"
-  enable_sitebridge            = var.enable_sitebridge
-  tags                         = var.tags
-  resource_prefix              = local.resource_prefix
-  vpc_id                       = module.vpc.vpc_id
-  private_subnet_ids           = module.vpc.private_subnet_ids
-  transit_gateway              = data.terraform_remote_state.stack_base.outputs.transit_gateway
-  sitebridge_sg_id             = module.eks_cluster.cluster_security_group_id
-  control_plane_ips            = var.sitebridge_config.control_plane_ips
-  data_plane_cidrs             = var.sitebridge_config.data_plane_cidrs
-  private_route_table_ids      = module.vpc.private_route_table_ids
-  forwarded_domains            = var.sitebridge_config.forwarded_domains
+  source                  = "../modules/sitebridge_vpc_routing"
+  enable_sitebridge       = var.enable_sitebridge
+  tags                    = var.tags
+  resource_prefix         = local.resource_prefix
+  vpc_id                  = module.vpc.vpc_id
+  private_subnet_ids      = module.vpc.private_subnet_ids
+  transit_gateway         = data.terraform_remote_state.stack_base.outputs.transit_gateway
+  sitebridge_sg_id        = module.eks_cluster.cluster_security_group_id
+  control_plane_ips       = var.sitebridge_config.control_plane_ips
+  data_plane_cidrs        = var.sitebridge_config.data_plane_cidrs
+  private_route_table_ids = module.vpc.private_route_table_ids
+  forwarded_domains       = var.sitebridge_config.forwarded_domains
 }
 
 ###############################

--- a/Infrastructure/provider/aws/inbound_data_plane/main.tf
+++ b/Infrastructure/provider/aws/inbound_data_plane/main.tf
@@ -133,6 +133,7 @@ module eks_cluster {
   node_group_desired_size   = var.inbound_data_plane_node_group_desired_size
   node_group_max_size       = var.inbound_data_plane_node_group_max_size
   node_group_min_size       = var.inbound_data_plane_node_group_min_size
+  eks_k8s_version           = var.eks_k8s_version
 }
 
 resource aws_ssm_parameter cluster_name {

--- a/Infrastructure/provider/aws/inbound_data_plane/variables.tf
+++ b/Infrastructure/provider/aws/inbound_data_plane/variables.tf
@@ -34,8 +34,11 @@ variable sfdc_vpn_cidrs {
     "204.14.239.82/32",
     # AmerWest1
     "13.110.54.0/26",
-    # CodeBuild
-    "52.43.76.88/29"]
+    # CodeBuild(usw1, usw2, use1, use2)
+    "13.56.32.200/29",
+    "52.43.76.88/29",
+    "34.228.4.208/28",
+    "52.15.247.208/29"]
 }
 variable inbound_vpc_cidr {
   description = "CIDR of the inbound VPC"
@@ -113,4 +116,9 @@ variable sitebridge_config {
     data_plane_cidrs  = []
     forwarded_domains = []
   }
+}
+variable eks_k8s_version {
+  type        = string
+  default     = "1.16"
+  description = "Desired Kubernetes master version. If version is not specified in the manifest, the default version is used at resource creation"
 }

--- a/Infrastructure/provider/aws/inbound_data_plane/variables.tf
+++ b/Infrastructure/provider/aws/inbound_data_plane/variables.tf
@@ -23,7 +23,7 @@ variable flow_logs_retention_in_days {
 variable sfdc_vpn_cidrs {
   description = "List of SFDC VPN CIDRs for access whitelisting"
   type        = list(string)
-  default     = [
+  default = [
     # AmerWest
     "204.14.239.17/32",
     "204.14.239.18/32",
@@ -38,7 +38,7 @@ variable sfdc_vpn_cidrs {
     "13.56.32.200/29",
     "52.43.76.88/29",
     "34.228.4.208/28",
-    "52.15.247.208/29"]
+  "52.15.247.208/29"]
 }
 variable inbound_vpc_cidr {
   description = "CIDR of the inbound VPC"

--- a/Infrastructure/provider/aws/modules/eks_cluster/main.tf
+++ b/Infrastructure/provider/aws/modules/eks_cluster/main.tf
@@ -19,6 +19,7 @@ resource aws_eks_cluster data_plane {
   name                      = var.cluster_name
   role_arn                  = var.cluster_role_arn
   enabled_cluster_log_types = var.enabled_cluster_log_types
+  version                   = var.eks_k8s_version
 
   vpc_config {
     endpoint_private_access = true

--- a/Infrastructure/provider/aws/modules/eks_cluster/main.tf
+++ b/Infrastructure/provider/aws/modules/eks_cluster/main.tf
@@ -66,7 +66,7 @@ resource aws_eks_node_group data_plane {
   }
 
   remote_access {
-    ec2_ssh_key               = var.node_group_key_name
+    ec2_ssh_key = var.node_group_key_name
     source_security_group_ids = [
       var.bastion_security_group_id
     ]

--- a/Infrastructure/provider/aws/modules/eks_cluster/variables.tf
+++ b/Infrastructure/provider/aws/modules/eks_cluster/variables.tf
@@ -47,6 +47,6 @@ variable node_group_min_size {
   type = number
 }
 variable eks_k8s_version {
-  type = string
+  type        = string
   description = "Desired Kubernetes master version. If version is not specified in the manifest, the default version is used at resource creation"
 }

--- a/Infrastructure/provider/aws/modules/eks_cluster/variables.tf
+++ b/Infrastructure/provider/aws/modules/eks_cluster/variables.tf
@@ -46,3 +46,7 @@ variable node_group_max_size {
 variable node_group_min_size {
   type = number
 }
+variable eks_k8s_version {
+  type = string
+  description = "Desired Kubernetes master version. If version is not specified in the manifest, the default version is used at resource creation"
+}

--- a/Infrastructure/provider/aws/outbound_data_plane/main.tf
+++ b/Infrastructure/provider/aws/outbound_data_plane/main.tf
@@ -120,6 +120,7 @@ module eks_cluster {
   node_group_desired_size   = var.outbound_data_plane_node_group_desired_size
   node_group_max_size       = var.outbound_data_plane_node_group_max_size
   node_group_min_size       = var.outbound_data_plane_node_group_min_size
+  eks_k8s_version           = var.eks_k8s_version
 }
 
 resource aws_ssm_parameter cluster_name {

--- a/Infrastructure/provider/aws/outbound_data_plane/main.tf
+++ b/Infrastructure/provider/aws/outbound_data_plane/main.tf
@@ -14,13 +14,13 @@ locals {
     The VPC requires fewer public addresses to be allocated compared to private addresses, so the last subnet CIDR in the
     prefix is used as a base CIDR for creating public subnets.
   */
-  vpc_config = var.outbound_vpcs_config[var.vpc_suffix]
-  vpc_cidr  = local.vpc_config["vpc_cidr"]
+  vpc_config              = var.outbound_vpcs_config[var.vpc_suffix]
+  vpc_cidr                = local.vpc_config["vpc_cidr"]
   public_subnet_base_cidr = cidrsubnet(local.vpc_cidr, 2, var.az_count)
-  private_subnet_cidrs = lookup(local.vpc_config,"vpc_private_subnet_cidrs", [
+  private_subnet_cidrs = lookup(local.vpc_config, "vpc_private_subnet_cidrs", [
     for i in range(var.az_count) : cidrsubnet(local.vpc_cidr, 2, i)
   ])
-  public_subnet_cidrs = lookup(local.vpc_config,"vpc_public_subnet_cidrs", [
+  public_subnet_cidrs = lookup(local.vpc_config, "vpc_public_subnet_cidrs", [
     for i in range(var.az_count) : cidrsubnet(local.public_subnet_base_cidr, 2, i)
   ])
 }
@@ -124,10 +124,10 @@ module eks_cluster {
 }
 
 resource aws_ssm_parameter cluster_name {
-  tags        = var.tags
-  name        = format("/%s-%s/%s/outbound-data-plane/%s/cluster-name", var.env_name, var.region, var.deployment_id, var.vpc_suffix)
-  type        = "SecureString"
-  value       = module.eks_cluster.cluster.name
+  tags  = var.tags
+  name  = format("/%s-%s/%s/outbound-data-plane/%s/cluster-name", var.env_name, var.region, var.deployment_id, var.vpc_suffix)
+  type  = "SecureString"
+  value = module.eks_cluster.cluster.name
 }
 
 ###############################
@@ -143,18 +143,18 @@ resource aws_ec2_transit_gateway_vpc_attachment tgw_attachment {
 }
 
 module sitebridge_vpc_routing {
-  source                       = "../modules/sitebridge_vpc_routing"
-  enable_sitebridge            = var.enable_sitebridge
-  tags                         = var.tags
-  resource_prefix              = local.resource_prefix
-  vpc_id                       = module.vpc.vpc_id
-  private_subnet_ids           = module.vpc.private_subnet_ids
-  transit_gateway              = data.terraform_remote_state.stack_base.outputs.transit_gateway
-  sitebridge_sg_id             = module.eks_cluster.cluster_security_group_id
-  control_plane_ips            = var.sitebridge_config.control_plane_ips
-  data_plane_cidrs             = var.sitebridge_config.data_plane_cidrs
-  private_route_table_ids      = module.vpc.private_route_table_ids
-  forwarded_domains            = var.sitebridge_config.forwarded_domains
+  source                  = "../modules/sitebridge_vpc_routing"
+  enable_sitebridge       = var.enable_sitebridge
+  tags                    = var.tags
+  resource_prefix         = local.resource_prefix
+  vpc_id                  = module.vpc.vpc_id
+  private_subnet_ids      = module.vpc.private_subnet_ids
+  transit_gateway         = data.terraform_remote_state.stack_base.outputs.transit_gateway
+  sitebridge_sg_id        = module.eks_cluster.cluster_security_group_id
+  control_plane_ips       = var.sitebridge_config.control_plane_ips
+  data_plane_cidrs        = var.sitebridge_config.data_plane_cidrs
+  private_route_table_ids = module.vpc.private_route_table_ids
+  forwarded_domains       = var.sitebridge_config.forwarded_domains
 }
 
 ###############################

--- a/Infrastructure/provider/aws/outbound_data_plane/variables.tf
+++ b/Infrastructure/provider/aws/outbound_data_plane/variables.tf
@@ -23,7 +23,7 @@ variable flow_logs_retention_in_days {
 variable sfdc_vpn_cidrs {
   description = "List of SFDC VPN CIDRs for access whitelisting"
   type        = list(string)
-  default     = [
+  default = [
     # AmerWest
     "204.14.239.17/32",
     "204.14.239.18/32",
@@ -38,11 +38,11 @@ variable sfdc_vpn_cidrs {
     "13.56.32.200/29",
     "52.43.76.88/29",
     "34.228.4.208/28",
-    "52.15.247.208/29"]
+  "52.15.247.208/29"]
 }
 
 variable "outbound_vpcs_config" {
-  type    = map
+  type = map
 }
 
 variable az_count {
@@ -106,7 +106,7 @@ variable vpc_suffix {
   type = string
 }
 variable eks_k8s_version {
-  type = string
-  default = "1.16"
+  type        = string
+  default     = "1.16"
   description = "Desired Kubernetes master version. If version is not specified in the manifest, the default version is used at resource creation"
 }

--- a/Infrastructure/provider/aws/outbound_data_plane/variables.tf
+++ b/Infrastructure/provider/aws/outbound_data_plane/variables.tf
@@ -34,8 +34,11 @@ variable sfdc_vpn_cidrs {
     "204.14.239.82/32",
     # AmerWest1
     "13.110.54.0/26",
-    # CodeBuild
-    "52.43.76.88/29"]
+    # CodeBuild(usw1, usw2, use1, use2)
+    "13.56.32.200/29",
+    "52.43.76.88/29",
+    "34.228.4.208/28",
+    "52.15.247.208/29"]
 }
 
 variable "outbound_vpcs_config" {
@@ -101,4 +104,9 @@ variable sitebridge_config {
 }
 variable vpc_suffix {
   type = string
+}
+variable eks_k8s_version {
+  type = string
+  default = "1.16"
+  description = "Desired Kubernetes master version. If version is not specified in the manifest, the default version is used at resource creation"
 }


### PR DESCRIPTION
- Add a new variable to take K8s Version from manifest
- Uses default version `1.16`[LATEST], if manifest does not include the version
- Update the CODEBUILD IPs for other regions to EKS Clusters