### PR TITLE
set write_local_pem_files as false for the default value

### DIFF
--- a/Infrastructure/provider/aws/stack_base/variables.tf
+++ b/Infrastructure/provider/aws/stack_base/variables.tf
@@ -37,7 +37,7 @@ variable monitoring_s3_bucket {
 variable write_local_pem_files {
   description = "If true, writes generated private keys as local pem files in the directory of the root module"
   type        = bool
-  default     = true
+  default     = false
 }
 variable enable_transit_gateway {
   description = "If false, skips creating the transit gateway."


### PR DESCRIPTION
Our CodePipelines utilize CodeBuild projects to run Terraform and k8s commands. CodeBuild projects are basically container-like environments with ephemeral filesystems that are lost between executions. As a result, not setting `write_local_pem_files` to false will always result in a diff when running `terraform plan` in these environments. This change sets the default to false to avoid the need of specifying this in each manifest.
